### PR TITLE
Closes #1: Slimmed the image from 819MB to 508MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,15 @@ FROM debian:jessie
 MAINTAINER Andrew Dunham <andrew@du.nham.ca>
 
 # Set up environment
-ENV LLVM_VERSION        3.7.0
-ENV MUSL_VERSION        1.1.12
-ENV RUST_BUILD_TARGET   all
-ENV RUST_BUILD_INSTALL  true
-ENV RUST_BUILD_CLEAN    true
+ENV LLVM_VERSION=3.7.0 \
+    MUSL_VERSION=1.1.12 \
+    RUST_BUILD_TARGET=all \
+    RUST_BUILD_INSTALL=true \
+    RUST_BUILD_CLEAN=true
 
-# Install dependencies (this isn't in the build script because it takes
-# forever, and running it here means it can be cached).
+ADD build.sh /build/build.sh
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade -yy && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yy \
+    BUILD_DEPENDENCIES="\
         automake        \
         build-essential \
         cmake           \
@@ -24,7 +22,7 @@ RUN apt-get update && \
         python          \
         subversion      \
         texinfo         \
-        wget
-
-ADD build.sh /build/build.sh
-RUN /build/build.sh
+        wget" && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yy gcc $BUILD_DEPENDENCIES && \
+    /build/build.sh && \
+    DEBIAN_FRONTEND=noninteractive apt-get remove -yy --auto-remove --purge $BUILD_DEPENDENCIES

--- a/build.sh
+++ b/build.sh
@@ -4,46 +4,45 @@ set -e
 set -o pipefail
 set -x
 
-
+CPU_COUNT="$(grep -c processor /proc/cpuinfo)"
 BUILD_DIR=/build
 
 
 function install_musl() {
     echo "** Installing musl"
-    cd ${BUILD_DIR}
+    cd "${BUILD_DIR}"
 
     if [ -d "/usr/local/musl" ]; then
         return
     fi
 
-    curl -LO http://www.musl-libc.org/releases/musl-${MUSL_VERSION}.tar.gz
-    tar zxvf musl-${MUSL_VERSION}.tar.gz
-    cd musl-${MUSL_VERSION}
+    curl -L "http://www.musl-libc.org/releases/musl-${MUSL_VERSION}.tar.gz" | tar zxf -
+    cd "musl-${MUSL_VERSION}"
     ./configure
-    make -j4
+    make -j"${CPU_COUNT}"
     make install
 }
 
 function build_llvm_components() {
-    cd ${BUILD_DIR}
+    cd "${BUILD_DIR}"
 
     if [ -f "/usr/local/musl/lib/libunwind.a" ]; then
         return
     fi
 
     echo "** Fetching sources"
-    curl http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz | tar xJf -
-    curl http://llvm.org/releases/${LLVM_VERSION}/libunwind-${LLVM_VERSION}.src.tar.xz | tar xJf -
+    curl "http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz" | tar xJf -
+    curl "http://llvm.org/releases/${LLVM_VERSION}/libunwind-${LLVM_VERSION}.src.tar.xz" | tar xJf -
 
-    mv llvm-${LLVM_VERSION}.src llvm
-    mv libunwind-${LLVM_VERSION}.src libunwind
+    mv "llvm-${LLVM_VERSION}.src" llvm
+    mv "libunwind-${LLVM_VERSION}.src" libunwind
 
     echo "** Building libunwind"
 
-    cd ${BUILD_DIR}/libunwind
-    ln -s ${BUILD_DIR}/libcxxabi/include/__cxxabi_config.h ./include/__cxxabi_config.h
+    cd "${BUILD_DIR}/libunwind"
+    ln -s "${BUILD_DIR}/libcxxabi/include/__cxxabi_config.h" ./include/__cxxabi_config.h
     mkdir build && cd build
-    cmake -DLLVM_PATH=${BUILD_DIR}/llvm -DLIBUNWIND_ENABLE_SHARED=OFF ..
+    cmake -DLLVM_PATH="${BUILD_DIR}/llvm" -DLIBUNWIND_ENABLE_SHARED=OFF ..
     make
 
     echo "** Copying to output"
@@ -54,13 +53,14 @@ function build_llvm_components() {
 function build_rust() {
     echo "** Building rust"
 
-    cd ${BUILD_DIR}
+    cd "${BUILD_DIR}"
     if [ ! -d "${BUILD_DIR}/rust" ]; then
-        git clone --depth 1 https://github.com/rust-lang/rust.git
+        git clone --depth 1 "https://github.com/rust-lang/rust.git"
         cd rust
 
-        ./configure                             \
-            --target=x86_64-unknown-linux-musl  \
+        ./configure \
+            --disable-docs \
+            --target=x86_64-unknown-linux-musl \
             --musl-root=/usr/local/musl/
     else
         cd rust
@@ -68,7 +68,7 @@ function build_rust() {
 
     # These environment variables are set from the Dockerfile and control what
     # we build and whether we install the compiler.
-    make ${RUST_BUILD_TARGET}
+    make -j"${CPU_COUNT}" "${RUST_BUILD_TARGET}"
     if [ "x${RUST_BUILD_INSTALL}" == "xtrue" ]; then
         make install
     fi
@@ -81,22 +81,21 @@ function install_cargo() {
         return
     fi
 
-    cd ${BUILD_DIR}
-    curl -LO https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz
-    tar zxf cargo-nightly-x86_64-unknown-linux-gnu.tar.gz
+    cd "${BUILD_DIR}"
+    curl -L "https://static.rust-lang.org/cargo-dist/cargo-nightly-x86_64-unknown-linux-gnu.tar.gz" | tar zxf -
     USER=root ./cargo-nightly-x86_64-unknown-linux-gnu/install.sh
 }
 
 function cleanup() {
     if [ "x${RUST_BUILD_CLEAN}" == "xtrue" ]; then
-        rm -rf ${BUILD_DIR}
+        rm -rf "${BUILD_DIR}"
         apt-get clean
         rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
     fi
 }
 
 function main() {
-    mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
+    mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}"
 
     install_musl
     build_llvm_components


### PR DESCRIPTION
The basic idea was described in #1.

This was done by cleaning up the build dependencies, cached packages, apt-lists in the same layer as the build, and also by dropping the documentation (~80MB of HTML files).

Side bonus: I have added some quotes to the build.sh to make it just more bullet-proof.

This is tested on my side. It builds around 70 minutes on my machine (I've built it two times - the first time it took 73 minutes and the second time - 69 minutes). BTW, the longest time it takes to clone the git repo submodules (especially, LLVM), but I haven't succeded with a better setup for git clone, though I didn't push it too hard. ([`git clone --depth 1` results in a shallow clone of the base repo, but fetches the submodules completely](http://stackoverflow.com/questions/27188899/shallow-clone-with-submodules-in-git-how-to-use-pointed-commits-and-not-latest))
