### PR TITLE
Use released Rust tar-balls instead of git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Andrew Dunham <andrew@du.nham.ca>
 # Set up environment
 ENV LLVM_VERSION=3.7.0 \
     MUSL_VERSION=1.1.12 \
+    RUST_VERSION=nightly \
     RUST_BUILD_TARGET=all \
     RUST_BUILD_INSTALL=true \
     RUST_BUILD_CLEAN=true
@@ -16,13 +17,10 @@ RUN apt-get update && \
         cmake           \
         curl            \
         file            \
-        git             \
         make            \
         pkg-config      \
         python          \
-        subversion      \
-        texinfo         \
-        wget" && \
+    " && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yy gcc $BUILD_DEPENDENCIES && \
     /build/build.sh && \
     DEBIAN_FRONTEND=noninteractive apt-get remove -yy --auto-remove --purge $BUILD_DEPENDENCIES

--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,9 @@ function build_rust() {
 
     cd "${BUILD_DIR}"
     if [ ! -d "${BUILD_DIR}/rust" ]; then
-        git clone --depth 1 "https://github.com/rust-lang/rust.git"
+        curl "https://static.rust-lang.org/dist/rustc-${RUST_VERSION}-src.tar.gz" | tar xzf -
+        mv "rustc-${RUST_VERSION}" rust
+
         cd rust
 
         ./configure \


### PR DESCRIPTION
It would be also great to have images for stable (1.6.0) and beta releases on Docker Hub. (You can create several branches with just `RUST_VERSION=1.6.0` and `RUST_VERSION=beta` changes, and link them on Docker Hub)

P.S. Please, add a link to Debian image on Docker Hub (in Build Settings) so your images get rebuilt on every Debian image update.
